### PR TITLE
ジャンル検索の修正

### DIFF
--- a/app/controllers/public/homes_controller.rb
+++ b/app/controllers/public/homes_controller.rb
@@ -2,7 +2,6 @@ class Public::HomesController < ApplicationController
   def top
     @items = Item.order(id: "DESC").where(is_active: true).first(4)
     @genre_type = "全て"
-    @item_count = Item.where(is_active: true).last(4).count
     @genres = Genre.all
   end
 end

--- a/app/controllers/public/items_controller.rb
+++ b/app/controllers/public/items_controller.rb
@@ -1,9 +1,11 @@
 class Public::ItemsController < ApplicationController
 
   def index
-    if params[:name] != nil
-      @items = Genre.find_by("name LIKE?", "%#{params[:name]}%").items
-      @genre_type = params[:name]
+    genre_id = params[:genre_id]
+    genre_name = params[:name]
+    if genre_id != nil
+      @items = Item.where(genre_id: genre_id)
+      @genre_type = genre_name
       @item_count = @items.where(is_active: true).count
     else
       @items = Item.all

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -12,7 +12,7 @@
             <div><%= link_to '全て', items_path %></div>
             <% @genres.each do |genre| %>
               <div>
-                <%= link_to genre.name, items_path(name: genre.name) %>
+                <%= link_to genre.name, items_path(genre_id: genre.id, name: genre.name) %>
               </div>
             <% end %>
           </div>

--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -1,9 +1,5 @@
 <div class="container-fluid">
   <div class="row">
-    <%= link_to "管理者ページ", admin_path %>
-  </div>
-
-  <div class="row">
     <div class="col-md-3">
       <div class="row">
         <div class="col text-center">
@@ -12,7 +8,7 @@
             <div><%= link_to '全て', items_path %></div>
             <% @genres.each do |genre| %>
               <div>
-                <%= link_to genre.name, items_path(name: genre.name) %>
+                <%= link_to genre.name, items_path(genre_id: genre.id, name: genre.name) %>
               </div>
             <% end %>
           </div>


### PR DESCRIPTION
# サイドバージャンル検索機能の修正
  - クエリパラメーターをgennre_idとgenre_nameを渡す方式に変更
  - genre_idで商品の検索を行い、genre_typeにはgenre_nameを渡すことでgenre検索を省略した。